### PR TITLE
Fix PDF parsing test dependency

### DIFF
--- a/app/Contracts/ResumeParser.php
+++ b/app/Contracts/ResumeParser.php
@@ -1,0 +1,7 @@
+<?php
+namespace App\Contracts;
+
+interface ResumeParser
+{
+    public function getText(string $path): string;
+}

--- a/app/Http/Controllers/ResumesController.php
+++ b/app/Http/Controllers/ResumesController.php
@@ -6,10 +6,14 @@ use App\Models\Resume;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
-use Spatie\PdfToText\Pdf;
+use App\Contracts\ResumeParser;
 
 class ResumesController
 {
+    public function __construct(private ResumeParser $parser)
+    {
+    }
+
     public function index(Request $request): \Illuminate\Http\JsonResponse
     {
         $resumes = $request->user()->resumes()->latest('created_at')->limit(5)->get()->map(fn($resume) => [
@@ -43,7 +47,7 @@ class ResumesController
         }
 
         // todo: parse content
-        $content = str(Pdf::getText(Storage::disk('local')->path($path)))
+        $content = str($this->parser->getText(Storage::disk('local')->path($path)))
             ->replaceMatches('/[^0-9A-z\n -.\/]/', '')
             ->replaceMatches('/\n\s*\n\s*\n/', '')
         ;

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,8 @@ namespace App\Providers;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\ServiceProvider;
+use App\Contracts\ResumeParser;
+use App\Services\SpatieResumeParser;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -13,6 +15,8 @@ class AppServiceProvider extends ServiceProvider
     public function register(): void
     {
         Model::unguard();
+
+        $this->app->singleton(ResumeParser::class, SpatieResumeParser::class);
     }
 
     /**

--- a/app/Services/SpatieResumeParser.php
+++ b/app/Services/SpatieResumeParser.php
@@ -1,0 +1,13 @@
+<?php
+namespace App\Services;
+
+use App\Contracts\ResumeParser;
+use Spatie\PdfToText\Pdf;
+
+class SpatieResumeParser implements ResumeParser
+{
+    public function getText(string $path): string
+    {
+        return Pdf::getText($path);
+    }
+}

--- a/tests/Fixtures/resume-example.txt
+++ b/tests/Fixtures/resume-example.txt
@@ -1,0 +1,2 @@
+Eduardo Fleck Dalla Vecchia
+Experienced software engineer

--- a/tests/Support/FakeResumeParser.php
+++ b/tests/Support/FakeResumeParser.php
@@ -1,0 +1,12 @@
+<?php
+namespace Tests\Support;
+
+use App\Contracts\ResumeParser;
+
+class FakeResumeParser implements ResumeParser
+{
+    public function getText(string $path): string
+    {
+        return file_get_contents(__DIR__.'/../Fixtures/resume-example.txt');
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,7 +4,15 @@ namespace Tests;
 
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
+use App\Contracts\ResumeParser;
+use Tests\Support\FakeResumeParser;
+
 abstract class TestCase extends BaseTestCase
 {
-    //
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->bind(ResumeParser::class, FakeResumeParser::class);
+    }
 }


### PR DESCRIPTION
## Summary
- abstract PDF extraction behind a `ResumeParser` interface
- use `SpatieResumeParser` in production
- bind a `FakeResumeParser` during tests
- add short text fixture for fake parser

## Testing
- `php -l app/Contracts/ResumeParser.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f7e075c9c8324914b6bd0b5833bd3