### PR TITLE
Add cancel edit feature

### DIFF
--- a/app/Http/Controllers/OptimizationController.php
+++ b/app/Http/Controllers/OptimizationController.php
@@ -221,6 +221,20 @@ class OptimizationController
         return response()->json([], 201);
     }
 
+    public function cancel(Optimization $optimization): \Illuminate\Http\JsonResponse
+    {
+        abort_unless($optimization->user->is(request()->user()), 403);
+
+        $optimization->update([
+            'status' => 'complete',
+            'current_step' => 3,
+        ]);
+
+        return response()->json([
+            'optimization' => $optimization->fresh(),
+        ]);
+    }
+
     private function getCompatibilityScore(Optimization $optimization): int
     {
         if ($optimization->status !== 'complete') {

--- a/resources/js/components/CompleteOptimization.vue
+++ b/resources/js/components/CompleteOptimization.vue
@@ -29,6 +29,7 @@ const regenerate = () => {
     })
 }
 
+
 </script>
 
 <template>

--- a/resources/js/components/ui/steps/Buttons.vue
+++ b/resources/js/components/ui/steps/Buttons.vue
@@ -2,6 +2,7 @@
 import { useOptimizationWizardStore } from '@/stores/OptimizationWizardStore';
 import { Button } from '@/components/ui/button';
 import DeleteOptimization from '@/components/DeleteOptimization.vue';
+import { cancelOptimizationEdit } from '@/lib/axios';
 
 defineProps<{
     action: () => void
@@ -9,12 +10,24 @@ defineProps<{
 
 const state = useOptimizationWizardStore()
 
+const cancelEdit = () => {
+    cancelOptimizationEdit(state)
+}
+
 </script>
 <template>
     <div class="mt-2 xl:mt-0 flex xl:justify-end xl:items-center gap-2 xl:gap-4">
         <div class="flex-1" v-if="state.step > 0 || state.form.status === 'editing'">
             <DeleteOptimization />
         </div>
+        <Button v-if="state.form.status === 'editing'"
+                :disabled="state.loading"
+                type="button"
+                size="lg"
+                class="flex-1 xl:flex-none"
+                variant="outline"
+                @click.prevent="cancelEdit"
+        >Cancel</Button>
 
         <Button type="button"
                 size="lg"

--- a/resources/js/lib/axios.ts
+++ b/resources/js/lib/axios.ts
@@ -200,6 +200,22 @@ const downloadCoverLetter: (state: OptimizationWizardStore) => Promise<void> = (
     return downloadFile(url)
 }
 
+const cancelOptimizationEdit = (state: OptimizationWizardStore) => {
+    state.loading = true
+
+    const axios = Axios()
+
+    return axios.put(route('optimizations.cancel', state.form.optimizationId))
+        .then(response => {
+            state.clearErrors()
+            state.setOptimization(response.data.optimization)
+            state.form.status = 'complete'
+        })
+        .finally(() => {
+            state.loading = false
+        })
+}
+
 /*
  * Credits: https://stackoverflow.com/a/75039478/29766047,
  *          https://gist.github.com/javilobo8/097c30a233786be52070986d8cdb1743?permalink_comment_id=3788793#gistcomment-3788793
@@ -271,6 +287,7 @@ export {
     downloadOptimizedResume,
     downloadCoverLetter,
     deleteOptimization,
+    cancelOptimizationEdit,
     updateUserInstructions,
     getJobInformation,
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,6 +11,7 @@ Route::group(['middleware' => ['auth', 'verified']], function () {
     Route::get('/optimizations/{optimization}', [\App\Http\Controllers\OptimizationController::class, 'show'])->name('optimizations.show');
     Route::post('/optimizations/create', [\App\Http\Controllers\OptimizationController::class, 'store'])->name('optimizations.store');
     Route::put('/optimizations/{optimization}', [\App\Http\Controllers\OptimizationController::class, 'update'])->name('optimizations.update');
+    Route::put('/optimizations/{optimization}/cancel', [\App\Http\Controllers\OptimizationController::class, 'cancel'])->name('optimizations.cancel');
     Route::delete('/optimizations/{optimization}', [\App\Http\Controllers\OptimizationController::class, 'destroy'])->name('optimizations.destroy');
     Route::get('view-optimized/{optimization}', [\App\Http\Controllers\DownloadOptimizedResumeController::class, 'sample']);
 

--- a/tests/Feature/OptimizationControllerTest.php
+++ b/tests/Feature/OptimizationControllerTest.php
@@ -97,4 +97,24 @@ class OptimizationControllerTest extends TestCase
         $this->assertSame('application/pdf', $response->headers->get('content-type'));
         $this->assertSame('attachment; filename="'.$optimization->coverLetterFileName().'"', $response->headers->get('content-disposition'));
     }
+
+    #[Test]
+    function it_can_cancel_an_edit_and_restore_the_optimization()
+    {
+        $optimization = \App\Models\Optimization::factory()->create([
+            'status' => 'draft',
+            'current_step' => 1,
+            'ai_response' => ['compatibility_score' => 99],
+        ]);
+
+        $response = $this->actingAs($optimization->user)
+            ->put(route('optimizations.cancel', $optimization));
+
+        $response->assertSuccessful();
+
+        $optimization->refresh();
+
+        $this->assertSame('complete', $optimization->status);
+        $this->assertSame(3, $optimization->current_step);
+    }
 }


### PR DESCRIPTION
## Summary
- allow canceling in-progress edits by updating optimization status
- expose cancel endpoint in the API routes
- add axios helper for canceling edit and button in UI
- test controller cancel action
- move cancel button to wizard action buttons

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*
- `npm run format:check` *(fails: Cannot find package 'prettier-plugin-organize-imports')*
- `./vendor/bin/phpunit --stop-on-failure` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_685cecc7d2cc8324a5aa1b4c582c1a3b