### PR TITLE
chore(test): migrate remaining PHPUnit tests to Pest

### DIFF
--- a/tests/Feature/GetJobLinkInformationTest.php
+++ b/tests/Feature/GetJobLinkInformationTest.php
@@ -1,56 +1,25 @@
 <?php
 
-namespace Tests\Feature;
-
-use Symfony\Component\DomCrawler\Crawler;
-use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Facades\Http;
-use PHPUnit\Framework\Attributes\Test;
-use Tests\TestCase;
 
-class GetJobLinkInformationTest extends TestCase
-{
-    #[Test]
-    public function it_imports_the_job_information_from_linkedin()
-    {
-        Http::preventStrayRequests();
-        Http::fake([
-            'https://www.linkedin.com/jobs/view/*' => Http::response(
-                file_get_contents(__DIR__.'/../Fixtures/linkedin-sample.html')
-            ),
-        ]);
+test('it imports the job information from linkedin', function () {
+    Http::preventStrayRequests();
+    Http::fake([
+        'https://www.linkedin.com/jobs/view/*' => Http::response(
+            file_get_contents(__DIR__ . '/../Fixtures/linkedin-sample.html')
+        ),
+    ]);
 
-        $service = new \App\Services\JobCrawler();
+    $service = new \App\Services\JobCrawler();
 
-        $service->crawl('https://www.linkedin.com/jobs/view/4253350439/?alternateChannel=search&refId=wNitVig4Rl27bNGUPyfT2A%3D%3D&trackingId=fWHtBUEA4EN3G1KTMm7Bvw%3D%3D');
-        $service->loadJobInformation();
+    $service->crawl('https://www.linkedin.com/jobs/view/4253350439/?alternateChannel=search&refId=wNitVig4Rl27bNGUPyfT2A%3D%3D&trackingId=fWHtBUEA4EN3G1KTMm7Bvw%3D%3D');
+    $service->loadJobInformation();
 
+    expect($service->toArray())->toHaveCount(5);
+    expect($service->title)->toBe('Full Stack Developer');
+    expect($service->company)->toBe('The Patrick J. McGovern Foundation');
+    expect($service->location)->toBe('United States');
+    expect($service->description)->toContain('Proficiency in JavaScript');
+    expect($service->url)->toContain('https://www.linkedin.com/jobs/view/4253350439/');
+});
 
-        $this->assertCount(5, $service->toArray());
-        $this->assertEquals('Full Stack Developer', $service->title);
-        $this->assertEquals('The Patrick J. McGovern Foundation', $service->company);
-        $this->assertEquals('United States', $service->location);
-        $this->assertStringContainsString('Proficiency in JavaScript', $service->description);
-        $this->assertStringContainsString('https://www.linkedin.com/jobs/view/4253350439/', $service->url);
-    }
-
-//    #[Test]
-//    public function it_imports_the_job_information_from_indeed()
-//    {
-//        Http::preventStrayRequests();
-//        Http::fake([
-//            'https://www.indeed.com/viewjob?jk=4253350439&from=serp&vjk=4253350439' => Http::response(
-//                file_get_contents(__DIR__.'/../Fixtures/indeed-sample.html')
-//            ),
-//        ]);
-
-//        $service = new \App\Services\JobCrawler();
-//        $service->loadJobInformation('https://www.indeed.com/viewjob?from=appshareios&jk=3425b0b71e806c60');
-//        $this->assertCount(4, $service->toArray());
-//        $this->assertEquals('Full Stack Developer', $service->title);
-//        $this->assertEquals('The Patrick J. McGovern Foundation', $service->company);
-//        $this->assertEquals('United States', $service->location);
-//        $this->assertStringContainsString('Proficiency in JavaScript', $service->description);
-//    }
-
-}

--- a/tests/Feature/OptimizationControllerTest.php
+++ b/tests/Feature/OptimizationControllerTest.php
@@ -1,121 +1,103 @@
 <?php
 
-namespace Tests\Feature;
-
+use App\Models\Optimization;
+use App\Models\Resume;
 use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use PHPUnit\Framework\Attributes\Test;
-use Tests\TestCase;
 
-class OptimizationControllerTest extends TestCase
-{
-    use RefreshDatabase;
-    #[Test]
-    function it_creates_a_new_optimization_when_the_role_information_is_sent()
-    {
-        $response = $this->withHeader('X-CurrentStep', 0)
-            ->actingAs($user = User::factory()->create())
-            ->post('/optimizations/create', [
-                'name' => 'Backend Engineer',
-                'company' => 'Laravel',
-                'description' => 'Lore Ipsum!',
-                'url' => 'https://www.linkedin.com/jobs/view/4253350439/'
-            ]);
-
-        $response->assertSuccessful();
-
-        $this->assertDatabaseCount('optimizations', 1);
-        $this->assertDatabaseHas('optimizations', [
-            'role_name' => 'Backend Engineer',
-            'role_company' => 'Laravel',
-            'role_description' => 'Lore Ipsum!',
-            'current_step' => '1',
-            'user_id' => $user->id,
+test('it creates a new optimization when the role information is sent', function () {
+    $response = $this->withHeader('X-CurrentStep', 0)
+        ->actingAs($user = User::factory()->create())
+        ->post('/optimizations/create', [
+            'name' => 'Backend Engineer',
+            'company' => 'Laravel',
+            'description' => 'Lore Ipsum!',
+            'url' => 'https://www.linkedin.com/jobs/view/4253350439/'
         ]);
 
-        $this->assertSame($response->json('step'), 0);
-        $this->assertSame($response->json('optimization.role_name'), 'Backend Engineer');
-    }
+    $response->assertSuccessful();
 
-    #[Test]
-    function it_sets_an_existing_resume_in_the_optimization()
-    {
-        $optimization = \App\Models\Optimization::factory()->create([
-            'resume_id' => null,
-        ]);
-        $resume = \App\Models\Resume::factory()->create();
-        $response = $this->withHeader('X-CurrentStep', 1)
-            ->actingAs($optimization->user)
-            ->put(route('optimizations.update', $optimization), [
-                'id' => $resume->id,
-            ]);
+    $this->assertDatabaseCount('optimizations', 1);
+    $this->assertDatabaseHas('optimizations', [
+        'role_name' => 'Backend Engineer',
+        'role_company' => 'Laravel',
+        'role_description' => 'Lore Ipsum!',
+        'current_step' => '1',
+        'user_id' => $user->id,
+    ]);
 
-        $response->assertSuccessful();
+    expect($response->json('step'))->toBe(0);
+    expect($response->json('optimization.role_name'))->toBe('Backend Engineer');
+});
 
-        $this->assertDatabaseCount('optimizations', 1);
-        $this->assertDatabaseHas('optimizations', [
-            'id' => $optimization->id,
-            'current_step' => '2',
-            'user_id' => $optimization->user_id,
-            'resume_id' => $resume->id,
-        ]);
-
-        $this->assertTrue($optimization->fresh()->resume->is($resume));
-    }
-
-    #[Test]
-    function an_optimized_resume_can_be_downloaded()
-    {
-        // an optimized resume can be downloaded
-        $optimization = \App\Models\Optimization::factory()->create([
-            'optimized_result' => '<h1>John doe</h1><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Architecto cum doloribus necessitatibus praesentium quae quis sunt, voluptates. Cumque eos esse, ex facere, in maiores nobis obcaecati omnis placeat, recusandae veritatis!</p>'
+test('it sets an existing resume in the optimization', function () {
+    $optimization = Optimization::factory()->create([
+        'resume_id' => null,
+    ]);
+    $resume = Resume::factory()->create();
+    $response = $this->withHeader('X-CurrentStep', 1)
+        ->actingAs($optimization->user)
+        ->put(route('optimizations.update', $optimization), [
+            'id' => $resume->id,
         ]);
 
-        $response = $this->withToken($optimization->user->api_token)->post(route('optimizations.download', $optimization));
+    $response->assertSuccessful();
 
-        $response->assertSuccessful();
+    $this->assertDatabaseCount('optimizations', 1);
+    $this->assertDatabaseHas('optimizations', [
+        'id' => $optimization->id,
+        'current_step' => '2',
+        'user_id' => $optimization->user_id,
+        'resume_id' => $resume->id,
+    ]);
 
-        $this->assertSame('application/pdf', $response->headers->get('content-type'));
-        $this->assertSame('attachment; filename="'.$optimization->optimizedResumeFileName().'"', $response->headers->get('content-disposition'));
-    }
+    expect($optimization->fresh()->resume->is($resume))->toBeTrue();
+});
 
-    #[Test]
-    function a_cover_letter_can_be_downloaded()
-    {
-        // an optimized resume can be downloaded
-        $optimization = \App\Models\Optimization::factory()->create([
-            'ai_response' => [
-                'cover_letter' => [
-                    '<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ad aliquam animi architecto at dicta distinctio, eius est eveniet labore magni nobis quisquam sapiente! Accusantium consequatur dicta fuga laudantium non rem.</p>'
-                ],
-            ]
-        ]);
+test('an optimized resume can be downloaded', function () {
+    $optimization = Optimization::factory()->create([
+        'optimized_result' => '<h1>John doe</h1><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Architecto cum doloribus necessitatibus praesentium quae quis sunt, voluptates. Cumque eos esse, ex facere, in maiores nobis obcaecati omnis placeat, recusandae veritatis!</p>',
+    ]);
 
-        $response = $this->withToken($optimization->user->api_token)->post(route('optimizations.download-cover', $optimization));
+    $response = $this->withToken($optimization->user->api_token)->post(route('optimizations.download', $optimization));
 
-        $response->assertSuccessful();
+    $response->assertSuccessful();
 
-        $this->assertSame('application/pdf', $response->headers->get('content-type'));
-        $this->assertSame('attachment; filename="'.$optimization->coverLetterFileName().'"', $response->headers->get('content-disposition'));
-    }
+    expect($response->headers->get('content-type'))->toBe('application/pdf');
+    expect($response->headers->get('content-disposition'))->toBe('attachment; filename="' . $optimization->optimizedResumeFileName() . '"');
+});
 
-    #[Test]
-    function it_can_cancel_an_edit_and_restore_the_optimization()
-    {
-        $optimization = \App\Models\Optimization::factory()->create([
-            'status' => 'draft',
-            'current_step' => 1,
-            'ai_response' => ['compatibility_score' => 99],
-        ]);
+test('a cover letter can be downloaded', function () {
+    $optimization = Optimization::factory()->create([
+        'ai_response' => [
+            'cover_letter' => [
+                '<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ad aliquam animi architecto at dicta distinctio, eius est eveniet labore magni nobis quisquam sapiente! Accusantium consequatur dicta fuga laudantium non rem.</p>',
+            ],
+        ],
+    ]);
 
-        $response = $this->actingAs($optimization->user)
-            ->put(route('optimizations.cancel', $optimization));
+    $response = $this->withToken($optimization->user->api_token)->post(route('optimizations.download-cover', $optimization));
 
-        $response->assertSuccessful();
+    $response->assertSuccessful();
 
-        $optimization->refresh();
+    expect($response->headers->get('content-type'))->toBe('application/pdf');
+    expect($response->headers->get('content-disposition'))->toBe('attachment; filename="' . $optimization->coverLetterFileName() . '"');
+});
 
-        $this->assertSame('complete', $optimization->status);
-        $this->assertSame(3, $optimization->current_step);
-    }
-}
+test('it can cancel an edit and restore the optimization', function () {
+    $optimization = Optimization::factory()->create([
+        'status' => 'draft',
+        'current_step' => 1,
+        'ai_response' => ['compatibility_score' => 99],
+    ]);
+
+    $response = $this->actingAs($optimization->user)
+        ->put(route('optimizations.cancel', $optimization));
+
+    $response->assertSuccessful();
+
+    $optimization->refresh();
+
+    expect($optimization->status)->toBe('complete');
+    expect($optimization->current_step)->toBe(3);
+});
+


### PR DESCRIPTION
## Summary
- replace class-based OptimizationControllerTest with Pest-style tests
- convert GetJobLinkInformationTest to Pest with expectation API

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: curl error 56, CONNECT tunnel failed: response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688da792290083248c8bcbfff0f18e06